### PR TITLE
Update README.md with Alienware R10

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ In general, enthusiast / DIY boards will not have PSB, as fusing the CPU renders
 | Asus | Pro WS X570-ACE | Disabled |
 | Asus | ROG Strix B550-I | Disabled |
 | Gigabyte | X570s Aero G rev.1 | Disabled |
+| Alienware | Aurora Ryzen R10 (0TYR0X A00 ver.) | Enabled |


### PR DESCRIPTION
Added Alienware Aurora Ryzen R10 as enabled.
There are several reports on internet of people unable to trasplant their cpus to another mobo, I faced similar issues and this tool confirmed that Dell is indeed enabled PSB at least on this particular model.